### PR TITLE
Fix Payment object encoding

### DIFF
--- a/EasyPost/Payment.cs
+++ b/EasyPost/Payment.cs
@@ -8,7 +8,7 @@
 
 namespace EasyPost
 {
-    public class Payment
+    public class Payment : Resource
     {
         /// <summary>
         /// Defines the payment type. Supported values are "SENDER", "THIRD_PARTY", "RECEIVER", "COLLECT". Defaults to SENDER.


### PR DESCRIPTION
While using this project at work (Thanks for making it, it has saved us a lot of time), I ran into a small issue. Encoding the `Payment` object is currently broken. Instead of being converted properly as a dictionary like other objects such as `Options`, it is just using the class name (See below image). Making the `Payment` class extend `Resource` fixes the issue.
![image](https://user-images.githubusercontent.com/41750582/176002054-cbc15342-3774-4cf1-9ef3-1d2c7dccd40c.png)
