### PR TITLE
Duty Payment

### DIFF
--- a/EasyPost/DutyPayment.cs
+++ b/EasyPost/DutyPayment.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * Licensed under The MIT License (MIT)
+ *
+ * Copyright (c) 2014 EasyPost
+ * Copyright (C) 2017 AMain.com, Inc.
+ * All Rights Reserved
+ */
+
+namespace EasyPost
+{
+    public class DutyPayment : Resource
+    {
+        /// <summary>
+        /// Defines the payment type. Supported values are "SENDER", "THIRD_PARTY", "RECEIVER", "COLLECT". Defaults to SENDER.
+        /// </summary>
+        public string Type  { get; set; }
+
+        /// <summary>
+        /// Setting account number. Required for RECEIVER and THIRD_PARTY.
+        /// </summary>
+        public string Account { get; set; }
+
+        /// <summary>
+        /// Setting postal code that the account is based in. Required for RECEIVER and THIRD_PARTY.
+        /// </summary>
+        public string PostalCode { get; set; }
+
+        /// <summary>
+        /// Setting country code that the account is based in. Required for THIRD_PARTY.
+        /// </summary>
+        public string Country { get; set; }
+    }
+}

--- a/EasyPost/Options.cs
+++ b/EasyPost/Options.cs
@@ -336,6 +336,11 @@ namespace EasyPost
         public string DutyPaymentAccount { get; set; }
 
         /// <summary>
+        /// Duty payment account
+        /// </summary>
+        public DutyPayment DutyPayment { get; set; }
+
+        /// <summary>
         /// Group
         /// </summary>
         public string Group { get; set; }


### PR DESCRIPTION
EasyPost has an undocumented `duty_payment` field on `options`. It is not yet in any of their libraries, but it sounds like it may be soon. I needed it for work, so I made changes to my fork of this project. If you want the code, here it is, but I understand if you want to stay in line with the official API.
![image](https://user-images.githubusercontent.com/41750582/185510519-644d054d-a5ac-49a6-85d5-9e931d2dca20.png)
